### PR TITLE
ehn: query in project_expense

### DIFF
--- a/app/Models/Project_expense.php
+++ b/app/Models/Project_expense.php
@@ -101,12 +101,14 @@ EOT;
         $database = \Config\Database::connect();
         $sql = <<<EOT
 SELECT project_expense.*, 
+    expense_type.name AS expense_type_name,
     project.name,
     partner.name AS partner_name, 
     distributor.name AS distributor_name,
     supplier.trade_name AS supplier_name,
     CONCAT(adder.first_name, ' ', adder.last_name) AS added_by_name
 FROM project_expense
+LEFT JOIN expense_type ON expense_type_id = project_expense.expense_type_id
 LEFT JOIN project ON project.id = project_expense.project_id
 LEFT JOIN distributor ON distributor.id = project.distributor_id
 LEFT JOIN supplier ON supplier.id = project_expense.supplier_id


### PR DESCRIPTION
I enhanced the project expense query in the search function to show the account type name instead of the ID, because previously it was displaying the ID. So I updated the query to return the name.