### PR TITLE
enh: search by company and name under customer #90

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -35,7 +35,7 @@ class Database extends Config
         'hostname' => 'localhost',
         'username' => 'root',
         'password' => '',
-        'database' => 'myt_erp_update',
+        'database' => 'myt_erp',
          'DBDriver' => 'MySQLi',
         'DBPrefix' => '',
         'pConnect' => false,

--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -35,7 +35,7 @@ class Database extends Config
         'hostname' => 'localhost',
         'username' => 'root',
         'password' => '',
-        'database' => 'myt_erp',
+        'database' => 'myt_erp_update',
          'DBDriver' => 'MySQLi',
         'DBPrefix' => '',
         'pConnect' => false,

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -95,14 +95,19 @@ WHERE customer.is_deleted = 0
 EOT;
         $binds = [];
 
-        if ($name) {
+        if ($name && $company) {
+            // single search box sends the same term as name & company -> match either
+            $sql     .= " AND (customer.name REGEXP ? OR customer.company REGEXP ?)";
+            $name     = str_replace(' ', '|', $name);
+            $company  = str_replace(' ', '|', $company);
+            $binds[]  = $name;
+            $binds[]  = $company;
+        } elseif ($name) {
             $sql    .= " AND customer.name REGEXP ?";
             $name    = str_replace(' ', '|', $name);
             $binds[] = $name;
-        }
-
-        if ($company) {
-            $sql    .= " AND customer.name REGEXP ?";
+        } elseif ($company) {
+            $sql    .= " AND customer.company REGEXP ?";
             $company    = str_replace(' ', '|', $company);
             $binds[] = $company;
         }


### PR DESCRIPTION
## Customer search by name or company

### Summary
Adds the ability to search the Customer list by **company**, and fixes a backend bug where company search silently matched on the name column instead. The customer page now uses a single search box that matches **either** the customer name or the company.

### Changes
- `app/Models/Customer.php`: fix the `$company` branch to filter `customer.company`. When both `name` and `company` are supplied (the single search box sends the same term as both), match either column via `AND (customer.name REGEXP ? OR customer.company REGEXP ?)`. The standalone name-only / company-only branches are preserved for other callers.